### PR TITLE
Updating calls to external library functions so that the gitkitcli command compiles.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -8,4 +8,5 @@
 #
 # Names should be added to this file as:
 #     Name <email address>
+Josh McAdams <joshua.mcadams@gmail.com>
 


### PR DESCRIPTION
The ValidateToken call for the Google Identity Toolkit Go library now expects a slice of client ID strings instead of a single ID, so the calls to that method now have clientID wrapped in a slice.

The GetPasswd() call in the Gopass library now returns a password and error instead of just an error, so the immediate conversion of byte to string failed. Now the bytes and error are saved into variables, the error is checked, and the bytes are then converted into a string.

Committer: Josh McAdams joshua.mcadams@gmail.com
